### PR TITLE
Add Streamlit-based league dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,32 @@
 # Fantasy Football Dashboard
 
-This project collects utilities and experimentation for building a dashboard
-around NFL.com fantasy leagues. Core features include:
+This project collects utilities and experimentation for building a dashboard around NFL.com fantasy leagues. Core features include:
+
 - Playoff clinching probabilities (Monte Carlo simulation)
 - Paths to elimination / playoff scenarios
 - League dashboards with metrics your league will enjoy
 
-**League example:** I use NFL.com each year.  
+**League example:** I use NFL.com each year.
 League link: https://fantasy.nfl.com/league/845342 (ID: 845342)
 
 ## Playoff Probability Simulator
 
-The `playoff_probability.py` module contains a simple simulator. Provide your
-league's current standings and remaining schedule, and it will estimate the
-chance that each team makes the playoffs.
+The `playoff_probability.py` module contains a simple simulator. Provide your league's current standings and remaining schedule, and it will estimate the chance that each team makes the playoffs.
 
 ### Example
 
 ```bash
 python playoff_probability.py
+```
+
+## Dashboard
+
+A minimal Streamlit dashboard accepts an NFL.com league ID and displays raw league data.
+
+Run it locally with:
+
+```bash
+streamlit run dashboard.py
+```
+
+The app will prompt for your league ID and attempt to fetch data from the NFL.com API.

--- a/dashboard.py
+++ b/dashboard.py
@@ -1,0 +1,20 @@
+"""Streamlit app for exploring NFL.com fantasy leagues."""
+import streamlit as st
+
+from league_api import fetch_league_data
+
+
+def main() -> None:
+    st.title("Fantasy Football Dashboard")
+    league_id = st.text_input("Enter NFL.com league ID")
+    if league_id:
+        try:
+            data = fetch_league_data(league_id)
+            st.subheader("League Data")
+            st.json(data)
+        except Exception as exc:  # pragma: no cover - network errors
+            st.error(f"Failed to load league data: {exc}")
+
+
+if __name__ == "__main__":
+    main()

--- a/league_api.py
+++ b/league_api.py
@@ -1,0 +1,36 @@
+"""Utilities for interacting with NFL.com fantasy league API."""
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+try:  # pragma: no cover - optional dependency
+    import requests
+except ImportError:  # pragma: no cover - handled at runtime
+    requests = None  # type: ignore
+
+API_URL_TEMPLATE = "https://fantasy.nfl.com/league/{league_id}/settings?format=json"
+
+def fetch_league_data(league_id: str, session: Optional[object] = None) -> Dict[str, Any]:
+    """Fetch JSON data for the given league ID from NFL.com.
+
+    Parameters
+    ----------
+    league_id: str
+        The identifier of the fantasy league on NFL.com.
+    session: object, optional
+        Object with a ``get`` method returning a response with ``json`` and
+        ``raise_for_status`` attributes. If ``None`` the function attempts to
+        use :mod:`requests`.
+
+    Returns
+    -------
+    dict
+        Parsed JSON document describing the league.
+    """
+    sess = session or requests
+    if sess is None:  # pragma: no cover - executed only when requests missing
+        raise RuntimeError("The requests library is required to fetch league data")
+    url = API_URL_TEMPLATE.format(league_id=league_id)
+    response = sess.get(url)
+    response.raise_for_status()
+    return response.json()

--- a/tests/test_league_api.py
+++ b/tests/test_league_api.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+
+# Add project root to module search path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from league_api import fetch_league_data
+
+class DummyResponse:
+    def __init__(self, data):
+        self._data = data
+    def raise_for_status(self):
+        pass
+    def json(self):
+        return self._data
+
+class DummySession:
+    def __init__(self, data):
+        self.data = data
+        self.last_url = None
+    def get(self, url):
+        self.last_url = url
+        return DummyResponse(self.data)
+
+def test_fetch_league_data_uses_session_and_returns_json():
+    session = DummySession({"league": "test"})
+    data = fetch_league_data("123", session=session)
+    assert data["league"] == "test"
+    assert "123" in session.last_url


### PR DESCRIPTION
## Summary
- add `fetch_league_data` helper for pulling NFL.com league JSON
- build simple Streamlit dashboard to enter league ID and view data
- document dashboard usage and test league API utility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c5bad2ed2c83209c6e5f5b483e0730