### PR TITLE
Add utility to fetch league standings

### DIFF
--- a/league_api.py
+++ b/league_api.py
@@ -1,14 +1,21 @@
 """Utilities for interacting with NFL.com fantasy league API."""
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 try:  # pragma: no cover - optional dependency
     import requests
 except ImportError:  # pragma: no cover - handled at runtime
     requests = None  # type: ignore
 
+try:  # pragma: no cover - optional dependency
+    from bs4 import BeautifulSoup
+except ImportError:  # pragma: no cover - handled at runtime
+    BeautifulSoup = None  # type: ignore
+
 API_URL_TEMPLATE = "https://fantasy.nfl.com/league/{league_id}/settings?format=json"
+
+__all__ = ["fetch_league_data", "fetch_league_standings"]
 
 def fetch_league_data(league_id: str, session: Optional[object] = None) -> Dict[str, Any]:
     """Fetch JSON data for the given league ID from NFL.com.
@@ -50,3 +57,60 @@ def fetch_league_data(league_id: str, session: Optional[object] = None) -> Dict[
         return response.json()
     except ValueError as exc:
         raise ValueError("NFL.com returned malformed JSON data") from exc
+
+
+def fetch_league_standings(
+    league_id: str, session: Optional[object] = None
+) -> List[Dict[str, str]]:
+    """Fetch standings table for the given league ID from NFL.com.
+
+    Parameters
+    ----------
+    league_id: str
+        The identifier of the fantasy league on NFL.com.
+    session: object, optional
+        Object with a ``get`` method returning a response with ``text`` and
+        ``raise_for_status`` attributes. If ``None`` the function attempts to
+        use :mod:`requests`.
+
+    Returns
+    -------
+    list of dict
+        Each dictionary represents a team with keys ``team``, ``wlt``, ``pct``,
+        ``pts_for`` and ``pts_against``.
+    """
+
+    sess = session or requests
+    if sess is None:  # pragma: no cover - executed only when requests missing
+        raise RuntimeError(
+            "The requests library is required to fetch league standings"
+        )
+    if BeautifulSoup is None:  # pragma: no cover - executed only when bs4 missing
+        raise RuntimeError(
+            "The bs4 library is required to parse league standings"
+        )
+
+    url = f"https://fantasy.nfl.com/league/{league_id}"
+    response = sess.get(url)
+    response.raise_for_status()
+
+    soup = BeautifulSoup(response.text, "html.parser")
+
+    standings: List[Dict[str, str]] = []
+    rows = soup.select("table.tableType-team.hasGroups tbody tr")
+    for row in rows:
+        def cell_text(selector: str) -> str:
+            cell = row.select_one(selector)
+            return cell.get_text(strip=True) if cell else ""
+
+        standings.append(
+            {
+                "team": cell_text("td.team"),
+                "wlt": cell_text("td.wlt"),
+                "pct": cell_text("td.pct"),
+                "pts_for": cell_text("td.pts_for"),
+                "pts_against": cell_text("td.pts_against"),
+            }
+        )
+
+    return standings

--- a/tests/test_league_api.py
+++ b/tests/test_league_api.py
@@ -6,13 +6,14 @@ import pytest
 # Add project root to module search path
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from league_api import fetch_league_data
+from league_api import fetch_league_data, fetch_league_standings
 
 
 class DummyResponse:
-    def __init__(self, data, headers=None):
+    def __init__(self, data=None, headers=None, text=""):
         self._data = data
         self.headers = headers or {"Content-Type": "application/json"}
+        self.text = text
 
     def raise_for_status(self):
         pass
@@ -22,14 +23,15 @@ class DummyResponse:
 
 
 class DummySession:
-    def __init__(self, data, headers=None):
+    def __init__(self, data=None, text="", headers=None):
         self.data = data
+        self.text = text
         self.headers = headers
         self.last_url = None
 
     def get(self, url):
         self.last_url = url
-        return DummyResponse(self.data, headers=self.headers)
+        return DummyResponse(self.data, headers=self.headers, text=self.text)
 
 
 def test_fetch_league_data_uses_session_and_returns_json():
@@ -43,3 +45,46 @@ def test_fetch_league_data_errors_on_non_json():
     session = DummySession({}, headers={"Content-Type": "text/html"})
     with pytest.raises(ValueError):
         fetch_league_data("123", session=session)
+
+
+def test_fetch_league_standings_parses_html():
+    pytest.importorskip("bs4")
+    html = """
+    <table class="tableType-team hasGroups">
+        <tbody>
+            <tr>
+                <td class="team">Team A</td>
+                <td class="wlt">5-3-0</td>
+                <td class="pct">0.625</td>
+                <td class="pts_for">650.4</td>
+                <td class="pts_against">600.1</td>
+            </tr>
+            <tr>
+                <td class="team">Team B</td>
+                <td class="wlt">4-4-0</td>
+                <td class="pct">0.500</td>
+                <td class="pts_for">620.7</td>
+                <td class="pts_against">610.5</td>
+            </tr>
+        </tbody>
+    </table>
+    """
+    session = DummySession(text=html, headers={"Content-Type": "text/html"})
+    standings = fetch_league_standings("999", session=session)
+    assert standings == [
+        {
+            "team": "Team A",
+            "wlt": "5-3-0",
+            "pct": "0.625",
+            "pts_for": "650.4",
+            "pts_against": "600.1",
+        },
+        {
+            "team": "Team B",
+            "wlt": "4-4-0",
+            "pct": "0.500",
+            "pts_for": "620.7",
+            "pts_against": "610.5",
+        },
+    ]
+    assert "999" in session.last_url


### PR DESCRIPTION
## Summary
- add optional BeautifulSoup import and league standings scraper
- expose league standings via new `fetch_league_standings` function
- test standings parser with dummy HTML

## Testing
- `pip show beautifulsoup4`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5c65b760883209d7e84816f6ae1f6